### PR TITLE
Add host docker socket mount to dind containers

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -121,7 +121,7 @@ jenkins:
           resourceLimitMemory: 2500M
           resourceRequestCpu: 500m
           resourceRequestMemory: 750M
-          privileged: true
+          privileged: false
           ttyEnabled: true
       - name: docker
         label: docker
@@ -148,7 +148,7 @@ jenkins:
           resourceLimitMemory: 2500M
           resourceRequestCpu: 500m
           resourceRequestMemory: 750M
-          privileged: true
+          privileged: false
           ttyEnabled: true
       - name: helm
         label: helm
@@ -238,7 +238,7 @@ jenkins:
           resourceLimitMemory: 2500M
           resourceRequestCpu: 500m
           resourceRequestMemory: 750M
-          privileged: true
+          privileged: false
           ttyEnabled: true
         podRetention: never
         nodeUsageMode: NORMAL

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -84,6 +84,10 @@ jenkins:
         podRetention: never
         nodeUsageMode: NORMAL
         instanceCapStr: "5"
+        volumes:
+          - hostPathVolume:
+              mountPath: "/var/run/docker.sock"
+              hostPath: "/var/run/docker.sock"
         containers:
         - name: maven
           args: cat
@@ -117,13 +121,17 @@ jenkins:
           resourceLimitMemory: 2500M
           resourceRequestCpu: 500m
           resourceRequestMemory: 750M
-          privileged: false
+          privileged: true
           ttyEnabled: true
       - name: docker
         label: docker
         podRetention: never
         nodeUsageMode: NORMAL
         instanceCapStr: "5"
+        volumes:
+          - hostPathVolume:
+              mountPath: "/var/run/docker.sock"
+              hostPath: "/var/run/docker.sock"
         containers:
         - name: docker
           args: cat
@@ -140,7 +148,7 @@ jenkins:
           resourceLimitMemory: 2500M
           resourceRequestCpu: 500m
           resourceRequestMemory: 750M
-          privileged: false
+          privileged: true
           ttyEnabled: true
       - name: helm
         label: helm
@@ -193,6 +201,10 @@ jenkins:
             memory: false
       - name: golang-docker
         label: golang docker
+        volumes:
+          - hostPathVolume:
+              mountPath: "/var/run/docker.sock"
+              hostPath: "/var/run/docker.sock"
         containers:
         - name: golang
           args: cat
@@ -226,7 +238,7 @@ jenkins:
           resourceLimitMemory: 2500M
           resourceRequestCpu: 500m
           resourceRequestMemory: 750M
-          privileged: false
+          privileged: true
           ttyEnabled: true
         podRetention: never
         nodeUsageMode: NORMAL


### PR DESCRIPTION
I created a job that requires the docker command:
```
pipeline {
    agent {
        label 'docker'
    }
    stages {
        stage('env') {
            steps {
                container('docker') {
                    sh 'docker images'
                }
            }
        }
    }
}
```
The build failed with 
```
[Pipeline] {
[Pipeline] sh
+ docker images
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+ :
[Pipeline] }
```
Turns out the [original jenkins config](https://raw.githubusercontent.com/devops-workspace/jenkins-config/master/kubernetes.yaml) doesn't properly mount host docker socket in the dind container. This commit fixes the issue